### PR TITLE
Add redirects for login page buttons #158

### DIFF
--- a/dorm-mart/src/pages/AccountCreation/index.jsx
+++ b/dorm-mart/src/pages/AccountCreation/index.jsx
@@ -277,8 +277,8 @@ function CreateAccountPage() {
                   <span className="w-1 h-1 bg-black rounded-full" />
                   <a
                     href="#"
+                    onClick={(e) => { e.preventDefault(); navigate('/forgot-password'); }}
                     className="hover:underline hover:text-blue-300 transition-colors duration-200"
-                    onClick={(e)=>e.preventDefault()}
                   >
                     forgot password?
                   </a>

--- a/dorm-mart/src/pages/LoginPage.js
+++ b/dorm-mart/src/pages/LoginPage.js
@@ -100,7 +100,13 @@ function LoginPage() {
                     create account
                   </a>
                   <span className="w-1 h-1 bg-black rounded-full"></span>
-                  <a href="#" className="hover:underline hover:text-blue-400 transition-colors duration-200">forgot password?</a>
+                  <a 
+                    href="#" 
+                    onClick={(e) => { e.preventDefault(); navigate('/forgot-password'); }}
+                    className="hover:underline hover:text-blue-400 transition-colors duration-200"
+                  >
+                    forgot password?
+                  </a>
                 </div>
               </div>
             </div>

--- a/dorm-mart/src/pages/LoginPage.js
+++ b/dorm-mart/src/pages/LoginPage.js
@@ -92,7 +92,13 @@ function LoginPage() {
               {/* Links */}
               <div className="mt-6 text-center">
                 <div className="flex items-center justify-center space-x-2 text-base text-white">
-                  <a href="#" className="hover:underline hover:text-blue-400 transition-colors duration-200">create account</a>
+                  <a 
+                    href="#" 
+                    onClick={(e) => { e.preventDefault(); navigate('/create-account'); }}
+                    className="hover:underline hover:text-blue-400 transition-colors duration-200"
+                  >
+                    create account
+                  </a>
                   <span className="w-1 h-1 bg-black rounded-full"></span>
                   <a href="#" className="hover:underline hover:text-blue-400 transition-colors duration-200">forgot password?</a>
                 </div>


### PR DESCRIPTION
Now when you click on "Create Account" and "Forgot Password" they have correct onClick button funcionality. Forgot password's page just hasn't been implemented yet. 

Click here:
<img width="437" height="260" alt="image" src="https://github.com/user-attachments/assets/8822af02-a641-4f49-9157-0b815c709b98" />

To get to Anish's Page:
<img width="683" height="902" alt="image" src="https://github.com/user-attachments/assets/39cc63f7-e340-48d2-b604-9a8cbb90fcac" />
