### PR TITLE
Hot Fix: Bind Params

### DIFF
--- a/dorm-mart/api/auth/create_account.php
+++ b/dorm-mart/api/auth/create_account.php
@@ -225,7 +225,7 @@ $ins = $conn->prepare($sql);
 */
 $promotional = $promos ? 1 : 0;
 $ins->bind_param(
-  'ssiisiss',
+  'ssiisis',
   $firstName,
   $lastName,
   $gradMonth,


### PR DESCRIPTION
bind params in create_account.php did not previously match the number of params being passed. Fixed from 8 to 7.