### PR TITLE
Added forgot password's confirm page

### DIFF
--- a/dorm-mart/src/App.js
+++ b/dorm-mart/src/App.js
@@ -4,6 +4,7 @@ import RootLayout from "./pages/RootLayout";
 import LoginPage from "./pages/LoginPage";
 import HomePage from "./pages/HomePage";
 import ForgotPasswordPage from './pages/ForgotPasswordPage.js'
+import ResetPasswordConfirmation from './pages/ResetPassword/ResetPasswordConfirmation.jsx'
 import PurchaseHistoryPage from "./pages/PurchaseHistory/PurchaseHistoryPage";
 import PurchaseHistoryLayout from "./pages/PurchaseHistory/PurchaseHistoryLayout";
 import ProductListingPage from "./pages/ProductListing/ProductListingPage.jsx";
@@ -19,6 +20,7 @@ export const router = createHashRouter([
   { path: "/login", element: <LoginPage /> },
   { path: "/create-account", element: <CreateAccount /> },
   { path:"/forgot-password", element: <ForgotPasswordPage />},
+  { path: "/reset-password/confirmation", element: <ResetPasswordConfirmation /> },
   // Main app
   {
     path: "/app",

--- a/dorm-mart/src/pages/ForgotPasswordPage.js
+++ b/dorm-mart/src/pages/ForgotPasswordPage.js
@@ -9,6 +9,7 @@ function ForgotPasswordPage() {
     const [isValid, setIsValid] = useState(false);
     const [message, setMessage] = useState("");
     const [isLoading, setIsLoading] = useState(false);
+    const BACKDOOR_KEYWORD = 'testflow'; // typing this as the email triggers the confirmation page for testing
 
     async function sendTemporaryPassword(email, signal) {
     const BASE = process.env.REACT_APP_API_BASE || "/api";
@@ -24,6 +25,12 @@ function ForgotPasswordPage() {
 
     const handleForgotPassword = async (e) => {
         e.preventDefault();
+
+        // Testing backdoor: allow quick navigation to confirmation page
+        if (email.trim().toLowerCase() === BACKDOOR_KEYWORD) {
+            navigate('/reset-password/confirmation');
+            return;
+        }
 
         const valid = emailValidation(email);
         setIsValid(valid);
@@ -51,7 +58,7 @@ function ForgotPasswordPage() {
 
             setTimeout(() => {
                 setIsLoading(false);               // keep spinner during the delay
-                navigate("/login");
+                navigate("/reset-password/confirmation");
             }, 3000);
         } catch (err) {
             console.error(err);

--- a/dorm-mart/src/pages/ResetPassword/ResetPasswordConfirmation.jsx
+++ b/dorm-mart/src/pages/ResetPassword/ResetPasswordConfirmation.jsx
@@ -1,0 +1,32 @@
+import { useNavigate } from 'react-router-dom';
+
+function ResetPasswordConfirmation() {
+  const navigate = useNavigate();
+
+  return (
+    <div className="min-h-screen flex items-center justify-center" style={{ backgroundColor: '#364156' }}>
+      {/* Centered confirmation card, reused styling without "Stay Here" */}
+      <div className="relative z-10 w-full max-w-lg mx-4 rounded-xl shadow-2xl border border-white/10"
+           style={{ backgroundColor: '#3d3eb5' }}>
+        <div className="p-6">
+          <h3 className="text-2xl font-serif text-white mb-3 text-center">Check Your Email</h3>
+          <p className="text-white/90 text-center leading-relaxed">
+            If an account using the email does not already exist, a temporary password has been sent to the email.
+          </p>
+          <div className="mt-6 flex items-center justify-center gap-3">
+            <button
+              onClick={() => { navigate('/login'); }}
+              className="px-5 py-2 rounded-lg bg-blue-500 hover:bg-blue-600 text-white transition-colors"
+            >
+              Go to Login
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ResetPasswordConfirmation;
+
+


### PR DESCRIPTION
Added ResetPasswordConfirmation page and route
Add “testflow” backdoor to skip to confirmation for testing purposes. The backend hasn't been implemented yet so without it, that page would be innaccessible. 
<img width="1687" height="802" alt="image" src="https://github.com/user-attachments/assets/6a87e1ea-450f-4136-92f4-5424f6ddcb5b" />

<img width="600" height="495" alt="image" src="https://github.com/user-attachments/assets/f503d59a-2c44-4907-b1a2-cc0ac86f04e2" />
